### PR TITLE
Add MimeMagicImproveFromExtension hook for MW 1.39 (#1)

### DIFF
--- a/3DAlloy_body.php
+++ b/3DAlloy_body.php
@@ -42,6 +42,12 @@ class ThreeDimentionAlloy extends ImageHandler {
     $mime->addExtraInfo('application/sla [DRAWING]');
   }
 
+  public static function onMimeMagicImproveFromExtension( MimeAnalyzer $mimeAnalyzer, $ext, &$mime ) {
+	  if ( $mime !== 'application/json' && in_array( $ext, ['json', '3djson', '3dj', 'three', 'buff', 'buffjson'] ) ) {
+		  $mime = 'application/json';
+	  }
+  }
+
   static public function onParserFirstCallInit(Parser &$parser) {
     $parser->setFunctionHook("3d", "ThreeDimentionAlloy::parse3DFunc");
     $parser->setHook('3d', "ThreeDimentionAlloy::parse3DTag");

--- a/extension.json
+++ b/extension.json
@@ -63,7 +63,8 @@
     ],
     "MimeMagicInit": [
       "ThreeDimentionAlloy::onMimeMagicInit"
-    ]
+    ],
+    "MimeMagicImproveFromExtension": "ThreeDimentionAlloy::onMimeMagicImproveFromExtension"
   },
   "manifest_version": 1
 }


### PR DESCRIPTION
It fixed the error "File extension ".json" does not match the detected MIME type of the file (text/plain)." this happens when a user uploads a JSON file.